### PR TITLE
Add rules to check for DocBlock comments

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -261,16 +261,16 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "a077c4ad65b906768ed2f820701958b57f605be0"
+                "reference": "7029c051cd310e2e17c6caea3429bfbe290c41ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/a077c4ad65b906768ed2f820701958b57f605be0",
-                "reference": "a077c4ad65b906768ed2f820701958b57f605be0",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/7029c051cd310e2e17c6caea3429bfbe290c41ae",
+                "reference": "7029c051cd310e2e17c6caea3429bfbe290c41ae",
                 "shasum": ""
             },
             "require": {
@@ -320,20 +320,20 @@
                 "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
                 "source": "https://github.com/PHPCSStandards/PHPCSExtra"
             },
-            "time": "2023-01-09T22:15:31+00:00"
+            "time": "2023-03-28T17:48:27+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.1",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "4fd2e30c7465112ca2e3646037bfb9e6f0f4d4f3"
+                "reference": "0cfef5193e68e8ff179333d8ae937db62939b656"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/4fd2e30c7465112ca2e3646037bfb9e6f0f4d4f3",
-                "reference": "4fd2e30c7465112ca2e3646037bfb9e6f0f4d4f3",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/0cfef5193e68e8ff179333d8ae937db62939b656",
+                "reference": "0cfef5193e68e8ff179333d8ae937db62939b656",
                 "shasum": ""
             },
             "require": {
@@ -394,7 +394,7 @@
                 "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
                 "source": "https://github.com/PHPCSStandards/PHPCSUtils"
             },
-            "time": "2023-01-05T12:08:37+00:00"
+            "time": "2023-04-17T16:27:27+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -459,20 +459,20 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "f4d4ff58ddfe1ca79575e60c552543966a5ed7b2"
+                "reference": "fca9d9ef2dcd042658ccb9df16552f5048e7bb04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f4d4ff58ddfe1ca79575e60c552543966a5ed7b2",
-                "reference": "f4d4ff58ddfe1ca79575e60c552543966a5ed7b2",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/fca9d9ef2dcd042658ccb9df16552f5048e7bb04",
+                "reference": "fca9d9ef2dcd042658ccb9df16552f5048e7bb04",
                 "shasum": ""
             },
             "require": {
                 "ext-filter": "*",
                 "php": ">=5.4",
                 "phpcsstandards/phpcsextra": "^1.0",
-                "phpcsstandards/phpcsutils": "^1.0",
-                "squizlabs/php_codesniffer": "^3.7.1"
+                "phpcsstandards/phpcsutils": "^1.0.5",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
@@ -508,7 +508,7 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2023-03-07T17:51:30+00:00"
+            "time": "2023-05-01T08:34:06+00:00"
         }
     ],
     "aliases": [],

--- a/quality-tools/phpcs.xml.dist
+++ b/quality-tools/phpcs.xml.dist
@@ -32,21 +32,25 @@
 		</properties>
 	</rule>
 
-	<!-- Checks for @param, @return and @throws tags -->
+	<!-- Ensure documentation blocks follow basic formatting like containing a short description and not mixing tag groups. -->
+	<rule ref="Generic.Commenting.DocComment">
+		<!-- Ignore indentation as it conflicts with our attempts to align across multiple tag blocks. -->
+		<exclude name="Generic.Commenting.DocComment.TagValueIndent" />
+		<!-- Ignore @param tags not being first since normally start with @since and @version tags. -->
+		<exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
+	</rule>
+
+	<!-- Check that function comments exist and that they contain @param, @return and @throws tags. -->
 	<rule ref="Squiz.Commenting.FunctionComment">
 		<properties>
+			<!-- Ignore this sniff if @inheritDoc is present. -->
 			<property name="skipIfInheritdoc" value="true" />
 		</properties>
 	</rule>
 
+	<!-- Check that class comments exists. -->
 	<rule ref="Squiz.Commenting.ClassComment">
-		<!-- Needed so we ignore the presence of @version and @since tags -->
+		<!-- Ignore the presence of tags such as @version and @since. -->
 		<exclude name="Squiz.Commenting.ClassComment.TagNotAllowed" />
-	</rule>
-
-	<!-- Ensure each function has a description -->
-	<rule ref="Generic.Commenting.DocComment">
-		<exclude name="Generic.Commenting.DocComment.TagValueIndent" />
-		<exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
 	</rule>
 </ruleset>

--- a/quality-tools/phpcs.xml.dist
+++ b/quality-tools/phpcs.xml.dist
@@ -31,4 +31,22 @@
 			<property name="blank_line_check" value="true"/>
 		</properties>
 	</rule>
+
+	<!-- Checks for @param, @return and @throws tags -->
+	<rule ref="Squiz.Commenting.FunctionComment">
+		<properties>
+			<property name="skipIfInheritdoc" value="true" />
+		</properties>
+	</rule>
+
+	<rule ref="Squiz.Commenting.ClassComment">
+		<!-- Needed so we ignore the presence of @version and @since tags -->
+		<exclude name="Squiz.Commenting.ClassComment.TagNotAllowed" />
+	</rule>
+
+	<!-- Ensure each function has a description -->
+	<rule ref="Generic.Commenting.DocComment">
+		<exclude name="Generic.Commenting.DocComment.TagValueIndent" />
+		<exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
+	</rule>
 </ruleset>

--- a/quality-tools/phpcs.xml.dist
+++ b/quality-tools/phpcs.xml.dist
@@ -43,7 +43,7 @@
 	<!-- Check that function comments exist and that they contain @param, @return and @throws tags. -->
 	<rule ref="Squiz.Commenting.FunctionComment">
 		<properties>
-			<!-- Ignore this sniff if @inheritDoc is present. -->
+			<!-- Ignore missing tags if @inheritDoc is present. -->
 			<property name="skipIfInheritdoc" value="true" />
 		</properties>
 	</rule>


### PR DESCRIPTION
This PR adds rules to check for DocBlock comments in functions and classes.

`Squiz.Commenting.FunctionComment` checks for the presence of `@param`, `@return` and `@throws` tags and will also make sure function parameter names and descriptions are aligned like so:

```php
/**
 * Returns true if all the plugin's dependencies are met.
 *
 * @since 1.0.0
 * @version 1.0.0
 *
 * @param string|null $minimum_wc_version The minimum WooCommerce version required.
 * @param integer     $integer_param      An integer parameter.
 *
 * @return boolean
 */
public function is_active( string &$minimum_wc_version = null, int $integer_param ): bool {
```

Currently there's no sniff to check for `@since` or `@version` tags, so it also can not align them with `@param` tags. Though, I believe it's still an advantage to check for the presence of a DocBlock comment.

`Generic.Commenting.DocComment` is added so we ensure each function has a description in the DocBlock. The rule above only checks tags, not the description itself. This rule also ensures a sentence starts with a capital letter and ends with a period.

`Squiz.Commenting.ClassComment` handles checks for a class but we need to disable checks for invalid tags, as we may want to have `@since` and `@version`, but that does mean a class with a `@var` tag is valid.