### PR TITLE
Removing rules ElseExpression and UnusedFormalParameter; Updating LongVariable to 25 characters

### DIFF
--- a/quality-assurance/phpmd.dist.xml
+++ b/quality-assurance/phpmd.dist.xml
@@ -3,7 +3,9 @@
 	<rule ref="rulesets/cleancode.xml">
 		<exclude name="MissingImport"/>
 		<exclude name="StaticAccess"/>
+		<exclude name="ElseExpression" />
 	</rule>
+
 	<rule ref="rulesets/cleancode.xml/MissingImport">
 		<properties>
 			<property name="ignore-global" value="true"/>
@@ -12,6 +14,20 @@
 
 	<rule ref="rulesets/codesize.xml"/>
 	<rule ref="rulesets/design.xml"/>
-	<rule ref="rulesets/naming.xml"/>
-	<rule ref="rulesets/unusedcode.xml"/>
+	<rule ref="rulesets/naming.xml">
+		<exclude name="LongVariable" />
+	</rule>
+
+	<rule ref="rulesets/naming.xml/LongVariable">
+		<priority>1</priority>
+		<properties>
+			<property name="maximum" value="25"/>
+		</properties>
+	</rule>
+
+	<rule ref="rulesets/unusedcode.xml">
+		<!-- better covered by phpcs rules -->
+		<exclude name="UnusedFormalParameter" />
+	</rule>
+
 </ruleset>


### PR DESCRIPTION
Removing rules: 
- cleancode.xml/ElseExpression
- unusedcode.xml/UnusedFormalParameter. 
 
Setting maximum for naming.xml/LongVariable to 25